### PR TITLE
FEAT: Add TEACHER_ORG account type and update permissions

### DIFF
--- a/EduchemLP.Server/API/APIv1.cs
+++ b/EduchemLP.Server/API/APIv1.cs
@@ -277,7 +277,7 @@ public class APIv1(
     [HttpGet("adm/users")]
     public async Task<IActionResult> GetUsers(CancellationToken ct = default) {
         var acc = await auth.ReAuthFromContextOrNullAsync(ct);
-        if(acc?.Type < Account.AccountType.TEACHER) return new UnauthorizedObjectResult(new { success = false, message = "Nelze zobrazit uživatele, pokud nejsi přihlášený, nebo nemáš dostatečná práva." });
+        if(acc?.Type < Account.AccountType.TEACHER_ORG) return new UnauthorizedObjectResult(new { success = false, message = "Nelze zobrazit uživatele, pokud nejsi přihlášený, nebo nemáš dostatečná práva." });
 
         var users = await accounts.GetAllAsync(ct);
         var array = new JsonArray();
@@ -292,7 +292,7 @@ public class APIv1(
     [HttpPost("adm/users")]
     public async Task<IActionResult> AddUser([FromBody] Dictionary<string, object?> body, CancellationToken ct = default) {
         var loggedUser = await auth.ReAuthFromContextOrNullAsync(ct);
-        if(loggedUser == null || loggedUser.Type < Account.AccountType.TEACHER) return new UnauthorizedObjectResult(new { success = false, message = "Nelze zobrazit uživatele, pokud nejsi přihlášený, nebo nemáš dostatečná práva." });
+        if(loggedUser == null || loggedUser.Type < Account.AccountType.TEACHER_ORG) return new UnauthorizedObjectResult(new { success = false, message = "Nelze zobrazit uživatele, pokud nejsi přihlášený, nebo nemáš dostatečná práva." });
 
         string? email = body.TryGetValue("email", out var _email) ? _email?.ToString() : null;
         string? displayName = body.TryGetValue("displayName", out var _displayName) ? _displayName?.ToString() : null;
@@ -357,7 +357,7 @@ public class APIv1(
     public async Task<IActionResult> ResetUserPassword([FromBody] Dictionary<string, object?> data, CancellationToken ct = default) {
         // zjisteni prihlasenyho uzivatele + jeho perms
         var loggedAccount = await auth.ReAuthFromContextOrNullAsync(ct);
-        if(loggedAccount == null || loggedAccount.Type < Account.AccountType.TEACHER) return new UnauthorizedObjectResult(new { success = false, message = "Nelze zobrazit uživatele, pokud nejsi přihlášený, nebo nemáš dostatečná práva." });
+        if(loggedAccount == null || loggedAccount.Type < Account.AccountType.TEACHER_ORG) return new UnauthorizedObjectResult(new { success = false, message = "Nelze zobrazit uživatele, pokud nejsi přihlášený, nebo nemáš dostatečná práva." });
 
         // zjisteni id uzivatele kteryho chceme mazat
         int? id = data.TryGetValue("id", out var _id) ? int.TryParse(_id?.ToString(), out var _id2) ? _id2 : null : null;
@@ -409,7 +409,7 @@ public class APIv1(
     public async Task<IActionResult> EditUser([FromBody] Dictionary<string, object?> body, CancellationToken ct = default) {
         // zjisteni prihlasenyho uzivatele + jeho perms
         var loggedAccount = await auth.ReAuthFromContextOrNullAsync(ct);
-        if(loggedAccount == null || loggedAccount.Type < Account.AccountType.TEACHER) return new UnauthorizedObjectResult(new { success = false, message = "Nelze upravit uživatele, pokud nejsi přihlášený, nebo nemáš dostatečná práva." });
+        if(loggedAccount == null || loggedAccount.Type < Account.AccountType.TEACHER_ORG) return new UnauthorizedObjectResult(new { success = false, message = "Nelze upravit uživatele, pokud nejsi přihlášený, nebo nemáš dostatečná práva." });
 
         // zjisteni id uzivatele kteryho chceme mazat
         int? id = body.TryGetValue("id", out var _id) ? int.TryParse(_id?.ToString(), out var _id2) ? _id2 : null : null;
@@ -483,7 +483,7 @@ public class APIv1(
     [HttpGet("adm/logs")]
     public async Task<IActionResult> GetLogs(CancellationToken ct = default) {
         var acc = await auth.ReAuthFromContextOrNullAsync(ct);
-        if(acc == null || acc.Type < Account.AccountType.TEACHER) return new UnauthorizedObjectResult(new { success = false, message = "Nelze zobrazit logy, pokud nejsi přihlášený, nebo nemáš dostatečná práva." });
+        if(acc == null || acc.Type < Account.AccountType.TEACHER_ORG) return new UnauthorizedObjectResult(new { success = false, message = "Nelze zobrazit logy, pokud nejsi přihlášený, nebo nemáš dostatečná práva." });
 
         await using var conn = await db.GetOpenConnectionAsync(ct);
         if(conn == null) return new StatusCodeResult(500);

--- a/EduchemLP.Server/Classes/Objects/Account.cs
+++ b/EduchemLP.Server/Classes/Objects/Account.cs
@@ -100,6 +100,7 @@ public partial class Account {
     public enum AccountType {
         STUDENT,
         TEACHER,
+        TEACHER_ORG,
         ADMIN,
         SUPERADMIN,
     }

--- a/EduchemLP.Server/WebSockets/ChatWebSocketEndpoint.cs
+++ b/EduchemLP.Server/WebSockets/ChatWebSocketEndpoint.cs
@@ -297,7 +297,7 @@ public sealed class ChatWebSocketEndpoint(
         if (conn is null) return;
 
         // kdyz neni teacher/admin, smi smazat jen vlastni zpravu
-        if (client.AccountType < Account.AccountType.TEACHER) {
+        if (client.AccountType < Account.AccountType.TEACHER_ORG) {
             await using var checkCmd = conn.CreateCommand();
             checkCmd.CommandText = "SELECT user_id FROM chat WHERE uuid = @uuid";
             checkCmd.Parameters.AddWithValue("@uuid", messageUuid);

--- a/educhemlp.client/src/components/AppMenu.tsx
+++ b/educhemlp.client/src/components/AppMenu.tsx
@@ -60,7 +60,7 @@ export const AppMenu = ({ onClick }: AppMenuProps) => {
                 <p>Turnaje</p>
             </Link>
 
-            { AccountType[loggedUser?.type as unknown as keyof typeof AccountType] >= AccountType.TEACHER ?
+            { AccountType[loggedUser?.type as unknown as keyof typeof AccountType] >= AccountType.TEACHER_ORG ?
                 <Link to={"/app/administration"} onClick={onClick}  className={currentPage === "/app/administration" ? "active" : ""}>
                     <div style={{ maskImage: 'url(/images/icons/user_with_shield.svg)' }}></div>
                     <p>Administrace</p>

--- a/educhemlp.client/src/interfaces.ts
+++ b/educhemlp.client/src/interfaces.ts
@@ -37,6 +37,7 @@ export type AppSettings = {
 export enum AccountType {
     STUDENT,
     TEACHER,
+    TEACHER_ORG,
     ADMIN,
     SUPERADMIN,
 }

--- a/educhemlp.client/src/pages/app/Administration.tsx
+++ b/educhemlp.client/src/pages/app/Administration.tsx
@@ -134,6 +134,9 @@ function translateAccountType(type: AccountType | null | undefined, gender: Acco
         case "TEACHER" :
             if(g === "female") return "Učitelka";
             return "Učitel";
+        case "TEACHER_ORG"  :
+            if(g === "female") return "Učitelka (ORG)";
+            return "Učitel (ORG)";
         case "ADMIN" :
             if(g === "female") return "Administrátorka";
             return "Administrátor";
@@ -640,10 +643,14 @@ const UsersTab = () => {
                                         ) : (
                                             <select name="accountType" defaultValue={selectedUser?.type}>
                                                 <option value="STUDENT">{translateAccountType("STUDENT" as any, selectedUser?.gender )}</option>
-
                                                 {
                                                     enumIsGreater(loggedUser?.type?.toString(), AccountType, AccountType.TEACHER) ? (
                                                         <option value="TEACHER">{translateAccountType("TEACHER" as any, selectedUser?.gender )}</option>
+                                                    ) : null
+                                                }
+                                                {
+                                                    enumIsGreater(loggedUser?.type?.toString(), AccountType, AccountType.TEACHER_ORG) ? (
+                                                        <option value="TEACHER_ORG">{translateAccountType("TEACHER_ORG" as any, selectedUser?.gender )}</option>
                                                     ) : null
                                                 }
 
@@ -1379,12 +1386,12 @@ export const Administration = () => {
             return;
         }
 
-        if (loggedUser && enumIsSmaller(loggedUser?.type, AccountType, AccountType.TEACHER)) {
+        if (loggedUser && enumIsSmaller(loggedUser?.type, AccountType, AccountType.TEACHER_ORG)) {
             navigate("/app");
         }
     }, [userAuthed, loggedUser, navigate]);
 
-    if (!userAuthed || !loggedUser || !enumIsGreaterOrEquals(loggedUser?.type, AccountType, AccountType.TEACHER)) {
+    if (!userAuthed || !loggedUser || !enumIsGreaterOrEquals(loggedUser?.type, AccountType, AccountType.TEACHER_ORG)) {
         return null;
     }
 

--- a/educhemlp.client/src/pages/app/AppLayout.tsx
+++ b/educhemlp.client/src/pages/app/AppLayout.tsx
@@ -40,6 +40,13 @@ export const AppLayoutLoggedUserSection = ({ style }: { style?: CSSProperties}) 
             return "Učitel"
         }
 
+        else if(enumEquals(loggedUser.type.toString(), AccountType, AccountType.TEACHER_ORG)) {
+            if(enumEquals(account.gender?.toString(), AccountGender, AccountGender.FEMALE))
+                return "Učitelka"
+
+            return "Učitel"
+        }
+
         else if(enumEquals(loggedUser.type.toString(), AccountType, AccountType.ADMIN)) {
             if(enumEquals(account.gender?.toString(), AccountGender, AccountGender.FEMALE))
                 return "Administrátorka"

--- a/educhemlp.client/src/pages/app/Chat.tsx
+++ b/educhemlp.client/src/pages/app/Chat.tsx
@@ -531,7 +531,7 @@ export const Chat = () => {
                                                             />
 
                                                             {
-                                                               isOwn || enumIsGreaterOrEquals(loggedUser.type, AccountType, AccountType.TEACHER) ? (
+                                                               isOwn || enumIsGreaterOrEquals(loggedUser.type, AccountType, AccountType.TEACHER_ORG) ? (
                                                                     <TextWithIcon
                                                                         onClick={() => handleDeleteMessage(message.uuid) }
                                                                         color={"var(--error-color)"}


### PR DESCRIPTION
Introduces a new AccountType, TEACHER_ORG, in both server and client code. Updates permission checks and UI logic to require TEACHER_ORG or higher for administrative actions and chat message deletion, ensuring finer-grained access control. Also updates translations and select options for the new account type.