### PR TITLE
FEAT: Add AccountSchool field across backend, frontend & DB

### DIFF
--- a/EduchemLP.Server/API/APIv1.cs
+++ b/EduchemLP.Server/API/APIv1.cs
@@ -296,6 +296,7 @@ public class APIv1(
         string? @class = body.TryGetValue("class", out var _class) ? _class?.ToString() : null;
         string? accountType = body.TryGetValue("type", out var _accountType) ? _accountType?.ToString() : null;
         string? gender = body.TryGetValue("gender", out var _gender) ? _gender?.ToString() : null;
+        string? school = body.TryGetValue("school", out var _school) ? _school?.ToString() : null;
         bool sendToEmail = body.TryGetValue("sendToEmail", out var _sendToEmail) && bool.TryParse(_sendToEmail?.ToString(), out var _sendToEmail2) && _sendToEmail2;
         bool enableReservation = body.TryGetValue("enableReservation", out var _enableReservation) && bool.TryParse(_enableReservation?.ToString(), out var _enableReservation2) && _enableReservation2;
 
@@ -305,7 +306,8 @@ public class APIv1(
         if(loggedUser.Type < accountTypeParsed && loggedUser.Type != Account.AccountType.SUPERADMIN) return new UnauthorizedObjectResult(new { success = false, message = "Nemůžeš vytvořit uživatele s vyššími právy." });
 
         var genderParsed = Enum.TryParse(gender, out Account.AccountGender _g) ? _g : Account.AccountGender.OTHER;
-        var account = await accounts.CreateAsync(email, displayName, @class, genderParsed, accountTypeParsed, sendToEmail, enableReservation, ct);
+        var schoolParsed = Enum.TryParse(school, out Account.AccountSchool _s) ? _s : Account.AccountSchool.EDUCHEM;
+        var account = await accounts.CreateAsync(email, displayName, @class, genderParsed, schoolParsed, accountTypeParsed, sendToEmail, enableReservation, ct);
         if(account == null) return new JsonResult(new { success = false, message = "Chyba při vytváření uživatele." }) { StatusCode = 500};
 
         // zapassani do logu
@@ -425,6 +427,7 @@ public class APIv1(
         string? @class = body.TryGetValue("class", out var _class) ? _class?.ToString() : null;
         Account.AccountType? accountType = body.TryGetValue("type", out var _accountType) ? Enum.TryParse(_accountType?.ToString(), out Account.AccountType _ac) ? _ac : null : null;
         Account.AccountGender? gender = body.TryGetValue("gender", out var _gender) ? Enum.TryParse(_gender?.ToString(), out Account.AccountGender _g) ? _g : null : null;
+        Account.AccountSchool? school = body.TryGetValue("school", out var _school) ? Enum.TryParse(_school?.ToString(), out Account.AccountSchool _s) ? _s : null : null;
         bool? enableReservation = body.TryGetValue("enableReservation", out var _enableReservation) ? bool.TryParse(_enableReservation?.ToString(), out var _er) ? _er : null : null;
         email = email == "" ? null : email?.Trim();
         displayName = displayName == "" ? null : displayName?.Trim();
@@ -455,6 +458,7 @@ public class APIv1(
                 `class`=@class,
                 `account_type`=IF(@accountType IS NULL, account_type, @accountType),
                 `gender`=IF(@gender IS NULL, gender, @gender),
+                `school`=IF(@school IS NULL, school, @school),
                 `enable_reservation`=IF(@enableReservation IS NULL, enable_reservation, @enableReservation),
                 `last_updated`=NOW()
             WHERE id=@id;
@@ -467,6 +471,7 @@ public class APIv1(
         command.Parameters.AddWithValue("@class", @class);
         command.Parameters.AddWithValue("@accountType", accountType.ToString()?.ToUpper());
         command.Parameters.AddWithValue("@gender", gender.ToString()?.ToUpper());
+        command.Parameters.AddWithValue("@school", school?.ToString()?.ToUpper());
         command.Parameters.AddWithValue("@enableReservation", enableReservation);
 
 

--- a/EduchemLP.Server/Classes/Objects/Account.cs
+++ b/EduchemLP.Server/Classes/Objects/Account.cs
@@ -23,6 +23,7 @@ public partial class Account {
     public DateTime LastUpdated { get; private set; }
     public DateTime? LastLoggedIn { get; private set; }
     public AccountGender? Gender { get; private set; }
+    public AccountSchool School { get; private set; }
     public List<AccountAccessToken> AccessTokens { get; private set; }
 
     public bool EnableReservation { get; private set; }
@@ -30,7 +31,7 @@ public partial class Account {
 
 
     [JsonConstructor]
-    public Account(int id, string displayName, string email, string password, string? @class, AccountType type, DateTime createdAt, DateTime lastUpdated, DateTime? lastLoggedIn, AccountGender? gender, string? avatar, string? banner, List<AccountAccessToken>? accessTokens, bool enableReservation = false) {
+    public Account(int id, string displayName, string email, string password, string? @class, AccountType type, DateTime createdAt, DateTime lastUpdated, DateTime? lastLoggedIn, AccountGender? gender, AccountSchool school = AccountSchool.EDUCHEM, string? avatar = null, string? banner = null, List<AccountAccessToken>? accessTokens = null, bool enableReservation = false) {
         Id = id;
         DisplayName = displayName;
         Class = @class;
@@ -43,6 +44,7 @@ public partial class Account {
         Avatar = avatar;
         Banner = banner;
         Gender = gender;
+        School = school;
         AccessTokens = accessTokens ?? [];
         EnableReservation = enableReservation;
     }
@@ -58,6 +60,7 @@ public partial class Account {
         reader.GetDateTime("last_updated"),
         reader.GetValueOrNull<DateTime>("last_logged_in"),
         Enum.TryParse<Account.AccountGender>(reader.GetStringOrNull("gender"), out var _g ) ? _g : null,
+        Enum.TryParse<Account.AccountSchool>(reader.GetStringOrNull("school"), out var _s) ? _s : Account.AccountSchool.EDUCHEM,
         reader.GetStringOrNull("avatar"),
         reader.GetStringOrNull("banner"),
         JsonSerializer.Deserialize<List<Account.AccountAccessToken>>(reader.GetStringOrNull("access_tokens") ?? "[]", JsonSerializerOptions.Web) ?? [],
@@ -103,6 +106,12 @@ public partial class Account {
         TEACHER_ORG,
         ADMIN,
         SUPERADMIN,
+    }
+
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public enum AccountSchool {
+        EDUCHEM,
+        SSSMEP,
     }
 
     public sealed class AccountAccessToken {

--- a/EduchemLP.Server/Repositories/AccountRepository.cs
+++ b/EduchemLP.Server/Repositories/AccountRepository.cs
@@ -197,14 +197,14 @@ public class AccountRepository(
         http.HttpContext.Session.SetString("loggedaccount", sessionAcc.ToJsonString());
     }
 
-    public async Task<Account?> CreateAsync(string email, string displayName, string? @class, Account.AccountGender gender, Account.AccountType accountType, bool sendToEmail = false, bool enableReservation = false, CancellationToken ct = default) {
+    public async Task<Account?> CreateAsync(string email, string displayName, string? @class, Account.AccountGender gender, Account.AccountSchool school, Account.AccountType accountType, bool sendToEmail = false, bool enableReservation = false, CancellationToken ct = default) {
         await using var conn = await db.GetOpenConnectionAsync(ct);
         if (conn == null) return null;
 
         var password = Utilities.GenerateRandomPassword();
         const string insertQuery =
             """
-            INSERT INTO users (email, display_name, password, class, account_type, gender, enable_reservation) VALUES (@email, @displayName, @password, @class, @accountType, @gender, @enableReservation);
+            INSERT INTO users (email, display_name, password, class, account_type, gender, school, enable_reservation) VALUES (@email, @displayName, @password, @class, @accountType, @gender, @school, @enableReservation);
 
             SELECT * FROM users WHERE id = LAST_INSERT_ID();
             """;
@@ -215,6 +215,7 @@ public class AccountRepository(
         cmd.Parameters.AddWithValue("@class", @class);
         cmd.Parameters.AddWithValue("@accountType", accountType.ToString().ToUpper());
         cmd.Parameters.AddWithValue("@gender", gender.ToString().ToUpper());
+        cmd.Parameters.AddWithValue("@school", school.ToString().ToUpper());
         cmd.Parameters.AddWithValue("@enableReservation", enableReservation ? 1 : 0);
 
         await using var reader = await cmd.ExecuteReaderAsync(ct);

--- a/EduchemLP.Server/Repositories/IAccountRepository.cs
+++ b/EduchemLP.Server/Repositories/IAccountRepository.cs
@@ -7,7 +7,7 @@ public interface IAccountRepository {
     Task<List<Account>> GetAllAsync(CancellationToken ct = default);
     Task UpdateLastLoggedInAsync(Account account, CancellationToken ct = default);
     Task UpdateAvatarByConnectedPlatformAsync(Account account, CancellationToken ct = default);
-    Task<Account?> CreateAsync(string email, string displayName, string? @class, Account.AccountGender gender, Account.AccountType accountType, bool sendToEmail = false, bool enableReservation = false, CancellationToken ct = default);
+    Task<Account?> CreateAsync(string email, string displayName, string? @class, Account.AccountGender gender, Account.AccountSchool school, Account.AccountType accountType, bool sendToEmail = false, bool enableReservation = false, CancellationToken ct = default);
     Task<string?> GenerateDiscordAccessTokenAsync(Account account, CancellationToken ct = default);
     Task<string?> GenerateGoogleAccessTokenAsync(Account account, CancellationToken ct = default);
 }

--- a/EduchemLP.Server/WebSockets/ReservationsWebSocketEndpoint.cs
+++ b/EduchemLP.Server/WebSockets/ReservationsWebSocketEndpoint.cs
@@ -25,6 +25,7 @@ public sealed class ReservationsClient : WSClient {
     public string DisplayName { get; }
     public Account.AccountType? AccountType { get; }
     public string? Class { get; }
+    public Account.AccountSchool? School { get; }
     public string? Avatar { get; }
     public string? Banner { get; }
     public bool IsGuest { get; }
@@ -42,6 +43,7 @@ public sealed class ReservationsClient : WSClient {
             DisplayName = account.DisplayName;
             AccountType = account.Type;
             Class = account.Class;
+            School = account.School;
             Avatar = account.Avatar;
             Banner = account.Banner;
             IsGuest = false;
@@ -54,6 +56,7 @@ internal sealed record ReservationRow(
     int? UserId,
     string? UserDisplayName,
     string? UserClass,
+    Account.AccountSchool? UserSchool,
     string? UserAvatar,
     string? UserBanner,
     string? RoomId,
@@ -396,6 +399,7 @@ public sealed class ReservationsWebSocketEndpoint(
                 usr.id AS user_id,
                 usr.display_name AS user_display_name,
                 usr.class AS user_class,
+                usr.school AS user_school,
                 usr.avatar AS user_avatar,
                 usr.banner AS user_banner,
                 COALESCE(room.id, NULL) AS room_id, 
@@ -424,6 +428,7 @@ public sealed class ReservationsWebSocketEndpoint(
                 UserId: reader.GetValueOrNull<int>("user_id"),
                 UserDisplayName: reader.GetStringOrNull("user_display_name"),
                 UserClass: reader.GetStringOrNull("user_class"),
+                UserSchool: Enum.TryParse<Account.AccountSchool>(reader.GetStringOrNull("user_school"), out var userSchool) ? userSchool : null,
                 UserAvatar: reader.GetStringOrNull("user_avatar"),
                 UserBanner: reader.GetStringOrNull("user_banner"),
                 RoomId: reader.GetStringOrNull("room_id"),
@@ -515,6 +520,7 @@ public sealed class ReservationsWebSocketEndpoint(
 
                 if (client.AccountType is > Account.AccountType.STUDENT) {
                     userObj["class"] = row.UserClass;
+                    userObj["school"] = row.UserSchool?.ToString();
                 }
 
                 userNode = userObj;
@@ -618,7 +624,8 @@ public sealed class ReservationsWebSocketEndpoint(
             connectedUsers.Add(new JsonObject {
                 ["id"] = c.Id,
                 ["displayName"] = c.DisplayName,
-                ["class"] = c.AccountType > Account.AccountType.STUDENT ? c.Class : null
+                ["class"] = c.AccountType > Account.AccountType.STUDENT ? c.Class : null,
+                ["school"] = c.AccountType > Account.AccountType.STUDENT ? c.School?.ToString() : null
             });
         }
 

--- a/dbschema.sql
+++ b/dbschema.sql
@@ -30,11 +30,11 @@ USE `educhem_lan_party_dev`;
 
 -- --------------------------------------------------------
 
+
 --
 -- Struktura tabulky `announcements`
 --
 
-DROP TABLE IF EXISTS `announcements`;
 CREATE TABLE `announcements` (
                                  `id` int UNSIGNED NOT NULL,
                                  `author_id` int NOT NULL,
@@ -48,7 +48,6 @@ CREATE TABLE `announcements` (
 -- Struktura tabulky `chat`
 --
 
-DROP TABLE IF EXISTS `chat`;
 CREATE TABLE `chat` (
                         `user_id` int NOT NULL,
                         `message` varchar(1024) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL,
@@ -64,7 +63,6 @@ CREATE TABLE `chat` (
 -- Struktura tabulky `computers`
 --
 
-DROP TABLE IF EXISTS `computers`;
 CREATE TABLE `computers` (
                              `id` varchar(12) NOT NULL,
                              `room_id` varchar(12) DEFAULT NULL,
@@ -72,84 +70,12 @@ CREATE TABLE `computers` (
                              `available` tinyint(1) NOT NULL DEFAULT '1'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 
---
--- Vypisuji data pro tabulku `computers`
---
-
-INSERT INTO `computers` (`id`, `room_id`, `is_teachers_pc`, `available`) VALUES
-                                                                             ('ITH2_PC01', 'ITH2', 0, 1),
-                                                                             ('ITH2_PC02', 'ITH2', 0, 1),
-                                                                             ('ITH2_PC03', 'ITH2', 0, 1),
-                                                                             ('ITH2_PC04', 'ITH2', 0, 1),
-                                                                             ('ITH2_PC05', 'ITH2', 0, 1),
-                                                                             ('ITH2_PC06', 'ITH2', 0, 1),
-                                                                             ('ITH2_PC07', 'ITH2', 0, 1),
-                                                                             ('ITH2_PC08', 'ITH2', 0, 1),
-                                                                             ('ITH2_PC09', 'ITH2', 0, 1),
-                                                                             ('ITH2_PC10', 'ITH2', 0, 1),
-                                                                             ('ITH2_PC11', 'ITH2', 0, 1),
-                                                                             ('ITH2_PC12', 'ITH2', 0, 1),
-                                                                             ('ITH2_PC13', 'ITH2', 0, 1),
-                                                                             ('ITH2_PC14', 'ITH2', 0, 1),
-                                                                             ('ITH2_PC15', 'ITH2', 0, 1),
-                                                                             ('ITH2_PC16', 'ITH2', 0, 1),
-                                                                             ('ITH2_PC17', 'ITH2', 0, 1),
-                                                                             ('ITH2_PC18', 'ITH2', 0, 1),
-                                                                             ('ITH2_PC19', 'ITH2', 0, 1),
-                                                                             ('ITH2_PC20', 'ITH2', 0, 1),
-                                                                             ('ITH2_PC21', 'ITH2', 0, 1),
-                                                                             ('ITH2_PC22', 'ITH2', 0, 1),
-                                                                             ('ITH2_PC23', 'ITH2', 0, 1),
-                                                                             ('ITH2_PC24', 'ITH2', 0, 1),
-                                                                             ('ITH2_PC25', 'ITH2', 0, 1),
-                                                                             ('ITH2_PC26', 'ITH2', 0, 1),
-                                                                             ('ITH2_PC27', 'ITH2', 0, 1),
-                                                                             ('VRR_PC01', 'VRR', 0, 1),
-                                                                             ('VRR_PC02', 'VRR', 0, 1),
-                                                                             ('VRR_PC03', 'VRR', 0, 1),
-                                                                             ('VRR_PC04', 'VRR', 0, 1),
-                                                                             ('VRR_PC05', 'VRR', 0, 1),
-                                                                             ('VRR_PC06', 'VRR', 0, 1),
-                                                                             ('VRR_PC07', 'VRR', 0, 1),
-                                                                             ('VRR_PC08', 'VRR', 0, 1),
-                                                                             ('VRR_PC09', 'VRR', 1, 1),
-                                                                             ('VT2_PC01', 'VT2', 0, 0),
-                                                                             ('VT2_PC02', 'VT2', 0, 0),
-                                                                             ('VT2_PC03', 'VT2', 0, 0),
-                                                                             ('VT2_PC04', 'VT2', 0, 0),
-                                                                             ('VT2_PC05', 'VT2', 0, 0),
-                                                                             ('VT2_PC06', 'VT2', 0, 0),
-                                                                             ('VT2_PC07', 'VT2', 0, 0),
-                                                                             ('VT2_PC08', 'VT2', 0, 0),
-                                                                             ('VT2_PC09', 'VT2', 0, 0),
-                                                                             ('VT2_PC10', 'VT2', 0, 0),
-                                                                             ('VT2_PC11', 'VT2', 0, 0),
-                                                                             ('VT2_PC12', 'VT2', 0, 0),
-                                                                             ('VT2_PC13', 'VT2', 0, 0),
-                                                                             ('VT2_PC14', 'VT2', 0, 0),
-                                                                             ('VT2_PC15', 'VT2', 0, 0),
-                                                                             ('VT2_PC16', 'VT2', 0, 0),
-                                                                             ('VT2_PC17', 'VT2', 0, 0),
-                                                                             ('VT2_PC18', 'VT2', 0, 0),
-                                                                             ('VT2_PC19', 'VT2', 0, 0),
-                                                                             ('VT2_PC20', 'VT2', 0, 0),
-                                                                             ('VT2_PC21', 'VT2', 0, 0),
-                                                                             ('VT2_PC22', 'VT2', 0, 0),
-                                                                             ('VT2_PC23', 'VT2', 0, 0),
-                                                                             ('VT2_PC24', 'VT2', 0, 0),
-                                                                             ('VT2_PC25', 'VT2', 0, 0),
-                                                                             ('VT2_PC26', 'VT2', 0, 0),
-                                                                             ('VT2_PC27', 'VT2', 0, 0),
-                                                                             ('VT2_PC28', 'VT2', 0, 0),
-                                                                             ('VT2_PC29', 'VT2', 1, 0);
-
 -- --------------------------------------------------------
 
 --
 -- Struktura tabulky `logs`
 --
 
-DROP TABLE IF EXISTS `logs`;
 CREATE TABLE `logs` (
                         `id` int UNSIGNED NOT NULL,
                         `type` set('INFO','ERROR','WARN') NOT NULL DEFAULT 'INFO',
@@ -164,7 +90,6 @@ CREATE TABLE `logs` (
 -- Struktura tabulky `reservations`
 --
 
-DROP TABLE IF EXISTS `reservations`;
 CREATE TABLE `reservations` (
                                 `user_id` int NOT NULL,
                                 `room_id` varchar(12) DEFAULT NULL,
@@ -176,7 +101,6 @@ CREATE TABLE `reservations` (
 --
 -- Triggery `reservations`
 --
-DROP TRIGGER IF EXISTS `check_double_values_res`;
 DELIMITER $$
 CREATE TRIGGER `check_double_values_res` BEFORE UPDATE ON `reservations` FOR EACH ROW BEGIN
     IF (NEW.room_id IS NOT NULL AND NEW.computer_id IS NOT NULL) OR
@@ -187,7 +111,6 @@ CREATE TRIGGER `check_double_values_res` BEFORE UPDATE ON `reservations` FOR EAC
 END
 $$
 DELIMITER ;
-DROP TRIGGER IF EXISTS `check_double_values_res2`;
 DELIMITER $$
 CREATE TRIGGER `check_double_values_res2` BEFORE INSERT ON `reservations` FOR EACH ROW BEGIN
     IF (NEW.room_id IS NOT NULL AND NEW.computer_id IS NOT NULL) OR
@@ -198,7 +121,6 @@ CREATE TRIGGER `check_double_values_res2` BEFORE INSERT ON `reservations` FOR EA
 END
 $$
 DELIMITER ;
-DROP TRIGGER IF EXISTS `check_room_capacity`;
 DELIMITER $$
 CREATE TRIGGER `check_room_capacity` BEFORE INSERT ON `reservations` FOR EACH ROW BEGIN
     -- Deklarace proměnných
@@ -228,7 +150,6 @@ CREATE TRIGGER `check_room_capacity` BEFORE INSERT ON `reservations` FOR EACH RO
 END
 $$
 DELIMITER ;
-DROP TRIGGER IF EXISTS `check_room_capacity2`;
 DELIMITER $$
 CREATE TRIGGER `check_room_capacity2` BEFORE UPDATE ON `reservations` FOR EACH ROW BEGIN
     -- Deklarace proměnných
@@ -265,7 +186,6 @@ DELIMITER ;
 -- Struktura tabulky `rooms`
 --
 
-DROP TABLE IF EXISTS `rooms`;
 CREATE TABLE `rooms` (
                          `id` varchar(12) NOT NULL,
                          `label` varchar(32) DEFAULT NULL,
@@ -274,41 +194,16 @@ CREATE TABLE `rooms` (
                          `available` tinyint(1) NOT NULL DEFAULT '1'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 
---
--- Vypisuji data pro tabulku `rooms`
---
-
-INSERT INTO `rooms` (`id`, `label`, `image`, `limit_of_seats`, `available`) VALUES
-                                                                                ('07', 'Učebna 07', '07.jpg', 10, 1),
-                                                                                ('08', 'Učebna 08', '08.jpg', 16, 1),
-                                                                                ('DELICKA', 'Dělička', 'delicka.jpg', 8, 1),
-                                                                                ('ITH1', 'Učebna ITH1', 'vt3_2.jpg', 16, 1),
-                                                                                ('ITH2', 'Učebna ITH2', 'vt3_2.jpg', 0, 1),
-                                                                                ('ITH3', 'Učebna ITH3', 'vt3_2.jpg', 16, 1),
-                                                                                ('VRR', 'Učebna VRR+R', 'vrr.jpg', 5, 1),
-                                                                                ('VT2', 'VT2', 'vt3_2.jpg', 0, 1);
-
 -- --------------------------------------------------------
 
 --
 -- Struktura tabulky `settings`
 --
 
-DROP TABLE IF EXISTS `settings`;
 CREATE TABLE `settings` (
                             `property` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL,
                             `value` varchar(2048) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='data lze menit pouze v pripade, ze je aplikace vypnuta';
-
---
--- Vypisuji data pro tabulku `settings`
---
-
-INSERT INTO `settings` (`property`, `value`) VALUES
-                                                 ('chat_enabled', 'True'),
-                                                 ('reservations_enabled_from', '2025-11-25 20:00:00'),
-                                                 ('reservations_enabled_to', '2025-12-05 08:00:00'),
-                                                 ('reservations_status', 'OPEN');
 
 -- --------------------------------------------------------
 
@@ -316,21 +211,22 @@ INSERT INTO `settings` (`property`, `value`) VALUES
 -- Struktura tabulky `users`
 --
 
-DROP TABLE IF EXISTS `users`;
 CREATE TABLE `users` (
                          `id` int NOT NULL,
-                         `display_name` varchar(64) NOT NULL DEFAULT 'Neznámé jméno',
-                         `email` varchar(64) DEFAULT NULL,
-                         `password` varchar(1024) NOT NULL DEFAULT '_',
-                         `class` varchar(12) DEFAULT NULL,
-                         `gender` set('MALE','FEMALE','OTHER') DEFAULT NULL,
+                         `display_name` varchar(64) COLLATE utf8mb4_general_ci NOT NULL DEFAULT 'Neznámé jméno',
+                         `email` varchar(64) COLLATE utf8mb4_general_ci DEFAULT NULL,
+                         `password` varchar(1024) COLLATE utf8mb4_general_ci NOT NULL DEFAULT '_',
+                         `class` varchar(12) COLLATE utf8mb4_general_ci DEFAULT NULL,
+                         `gender` set('MALE','FEMALE','OTHER') COLLATE utf8mb4_general_ci DEFAULT NULL,
+                         `school` enum('EDUCHEM','SSSMEP') COLLATE utf8mb4_general_ci NOT NULL DEFAULT 'EDUCHEM',
+                         `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
                          `last_updated` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
                          `last_logged_in` datetime DEFAULT NULL,
-                         `account_type` enum('STUDENT','TEACHER','ADMIN','SUPERADMIN') CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL DEFAULT 'STUDENT',
-                         `avatar` varchar(1024) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci DEFAULT NULL,
-                         `banner` varchar(1024) DEFAULT NULL,
+                         `account_type` enum('STUDENT','TEACHER','TEACHER_ORG','ADMIN','SUPERADMIN') CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT 'STUDENT',
+                         `avatar` varchar(1024) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
+                         `banner` varchar(1024) COLLATE utf8mb4_general_ci DEFAULT NULL,
                          `enable_reservation` tinyint(1) NOT NULL DEFAULT '0'
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 -- --------------------------------------------------------
 
@@ -338,10 +234,9 @@ CREATE TABLE `users` (
 -- Struktura tabulky `users_access_tokens`
 --
 
-DROP TABLE IF EXISTS `users_access_tokens`;
 CREATE TABLE `users_access_tokens` (
                                        `user_id` int NOT NULL,
-                                       `platform` set('DISCORD','INSTAGRAM','GOOGLE','GITHUB') CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL,
+                                       `platform` set('DISCORD','INSTAGRAM','GOOGLE','GITHUB','FACEBOOK','TWITTER') CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL,
                                        `access_token` varchar(1024) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci DEFAULT NULL,
                                        `refresh_token` varchar(1024) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci DEFAULT NULL,
                                        `token_type` set('BEARER') CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL DEFAULT 'BEARER',
@@ -498,6 +393,7 @@ COMMIT;
 
 
 
+
 # vytvoreni uctu
 CREATE USER 'educhem_lan_party'@'%' IDENTIFIED BY 'educhem_lan_party';
 
@@ -511,32 +407,115 @@ SET NAMES 'utf8mb4';
 SET CHARACTER SET utf8mb4;
 ALTER TABLE users CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
 
-INSERT INTO `users` (`id`, `display_name`, `email`, `password`, `class`, `gender`, `last_updated`, `last_logged_in`, `account_type`, `avatar`, `banner`) VALUES
-(1, 'Administrator', 'admin@admin.admin', '$2a$11$7XnPVemd77pb8WWQItw5d.azyOvrGgKN941CxPTVYy3515cCOhZ0K', 'SPECIAL', 'OTHER', '2025-04-09 00:14:10', '2025-04-08 22:12:45', 'SUPERADMIN', 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSzrViu6UGEqo8eEnSGQkf8497JBfHSLViSoQ&s', 'https://drscdn.500px.org/photo/1113771318/q%3D80_m%3D600/v2?sig=c18424903b06b1b1595af3bd506268530d582216cc8e319b110d3dfe7ec2d242'),
-(2, 'Miloš Navrátil', 'milos.navratil@example.com', '_', '1.A', 'MALE', '2025-06-14 14:56:11', NULL, 'STUDENT', NULL, NULL),
-(3, 'Marek Svoboda', 'marek.svoboda@example.com', '_', NULL, 'MALE', '2025-06-14 14:56:11', NULL, 'TEACHER', 'https://imgv3.fotor.com/images/blog-cover-image/a-shadow-of-a-boy-carrying-the-camera-with-red-sky-behind.jpg', NULL),
-(4, 'Jana Pokorná', 'jana.pokorna@example.com', '_', NULL, 'FEMALE', '2025-06-14 14:56:11', NULL, 'ADMIN', 'https://iso.500px.com/wp-content/uploads/2016/02/stock-photo-114337435.jpg', NULL),
-(5, 'Natálie Novotná', 'natalie.novotna@example.com', '_', '2.B', 'FEMALE', '2025-06-14 14:56:11', NULL, 'STUDENT', 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcThisxh_l6BA8BgSe7z2MUiaRj553YtM11PNA&s', NULL),
-(6, 'Tomáš Dvořák', 'tomas.dvorak@example.com', '_', '3.A', 'MALE', '2025-06-14 14:59:34', NULL, 'STUDENT', 'https://img.freepik.com/free-photo/couple-making-heart-from-hands-sea-shore_23-2148019887.jpg?semt=ais_hybrid&w=740', NULL),
-(7, 'Lucie Králová', 'lucie.kralova@example.com', '_', '1.B', 'FEMALE', '2025-06-14 14:59:34', NULL, 'STUDENT', NULL, NULL),
-(8, 'Petr Černý', 'petr.cerny@example.com', '_', '2.A', 'MALE', '2025-06-14 14:59:34', NULL, 'STUDENT', 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRvFBa3G11OUBYADP7ouSBgwiiRzSYorF4dfg&s', NULL),
-(9, 'Eliška Horáková', 'eliska.horakova@example.com', '_', '3.B', 'FEMALE', '2025-06-14 14:59:34', NULL, 'STUDENT', NULL, NULL),
-(10, 'Adam Nový', 'adam.novy@example.com', '_', NULL, 'MALE', '2025-06-14 14:59:34', NULL, 'TEACHER', 'https://www.shutterstock.com/image-photo/passport-photo-portrait-young-man-260nw-2437772333.jpg', 'https://static.vecteezy.com/system/resources/thumbnails/022/902/924/small/ai-generative-modern-luxury-real-estate-house-for-sale-and-rent-luxury-property-residence-concept-photo.jpg'),
-(11, 'Simona Benešová', 'simona.benesova@example.com', '_', NULL, 'FEMALE', '2025-06-14 14:59:34', NULL, 'TEACHER', 'https://img.freepik.com/premium-photo/giving-rose-png-badge-sticker-valentines-day-photo-heart-shape-transparent-background_53876-950839.jpg?semt=ais_hybrid&w=740', 'https://static.vecteezy.com/system/resources/thumbnails/054/587/101/small_2x/romantic-rose-backdrop-with-intertwined-blooms-and-hearts-for-valentines-day-highlighting-love-and-passion-with-a-warm-color-palette-perfect-for-romantic-settings-and-event-design-concepts-photo.jpeg'),
-(12, 'Ondřej Kolář', 'ondrej.kolar@example.com', '_', '1.C', 'MALE', '2025-06-14 14:59:34', NULL, 'STUDENT', 'https://5.imimg.com/data5/SELLER/Default/2023/4/300935887/RK/PR/IE/4354612/img-20220703-wa0001-500x500.jpg', NULL),
-(13, 'Tereza Malá', 'tereza.mala@example.com', '_', '2.C', 'FEMALE', '2025-06-14 14:59:34', NULL, 'STUDENT', NULL, NULL),
-(14, 'Roman Havel', 'roman.havel@example.com', '_', NULL, 'MALE', '2025-06-14 14:59:34', NULL, 'ADMIN', NULL, NULL),
-(15, 'Barbora Němcová', 'barbora.nemcova@example.com', '_', '3.C', 'FEMALE', '2025-06-14 14:59:34', NULL, 'STUDENT', 'https://st2.depositphotos.com/2001755/5408/i/450/depositphotos_54081723-stock-photo-beautiful-nature-landscape.jpg', NULL),
-(16, 'Filip Růžička', 'filip.ruzicka@example.com', '_', '1.A', 'MALE', '2025-06-14 14:59:34', NULL, 'STUDENT', NULL, NULL),
-(17, 'Nikola Procházková', 'nikola.prochazkova@example.com', '_', '2.B', 'FEMALE', '2025-06-14 14:59:34', NULL, 'STUDENT', NULL, NULL),
-(18, 'Daniel Konečný', 'daniel.konecny@example.com', '_', '4.A', 'MALE', '2025-06-14 14:59:34', NULL, 'STUDENT', 'https://i.pinimg.com/236x/d3/4b/ec/d34becc9ecf6f8b4b5c861bf61109176.jpg', NULL),
-(19, 'Veronika Blažková', 'veronika.blazkova@example.com', '_', '1.B', 'FEMALE', '2025-06-14 14:59:34', NULL, 'STUDENT', NULL, NULL),
-(20, 'Jakub Fiala', 'jakub.fiala@example.com', '_', '3.A', 'MALE', '2025-06-14 14:59:34', NULL, 'STUDENT', NULL, NULL),
-(21, 'Kristýna Doležalová', 'kristyna.dolezalova@example.com', '_', NULL, 'FEMALE', '2025-06-14 14:59:34', NULL, 'ADMIN', NULL, NULL),
-(22, 'David Marek', 'david.marek@example.com', '_', '2.C', 'MALE', '2025-06-14 14:59:34', NULL, 'STUDENT', NULL, NULL),
-(23, 'Kateřina Holubová', 'katerina.holubova@example.com', '_', '3.B', 'FEMALE', '2025-06-14 14:59:34', NULL, 'STUDENT', NULL, NULL),
-(24, 'Matěj Šimek', 'matej.simek@example.com', '_', NULL, 'MALE', '2025-06-14 14:59:34', NULL, 'TEACHER', 'https://i.pinimg.com/236x/39/8f/da/398fdab4318b3baa65d36baf5ab3fab4.jpg', 'https://static8.depositphotos.com/1491329/1068/i/450/depositphotos_10687188-stock-photo-foggy-landscape-early-morning-mist.jpg'),
-(25, 'Alena Sedláčková', 'alena.sedlackova@example.com', '_', '1.C', 'FEMALE', '2025-06-14 14:59:34', NULL, 'STUDENT', NULL, NULL);
+INSERT INTO `settings` (`property`, `value`) VALUES
+                                                 ('chat_enabled', 'True'),
+                                                 ('reservations_enabled_from', '2025-11-25 20:00:00'),
+                                                 ('reservations_enabled_to', '2025-12-05 08:00:00'),
+                                                 ('reservations_status', 'OPEN');
+
+INSERT INTO `rooms` (`id`, `label`, `image`, `limit_of_seats`, `available`) VALUES
+                                                                                ('07', 'Učebna 07', '07.jpg', 10, 1),
+                                                                                ('08', 'Učebna 08', '08.jpg', 16, 1),
+                                                                                ('DELICKA', 'Dělička', 'delicka.jpg', 8, 1),
+                                                                                ('ITH1', 'Učebna ITH1', 'vt3_2.jpg', 16, 1),
+                                                                                ('ITH2', 'Učebna ITH2', 'vt3_2.jpg', 0, 1),
+                                                                                ('ITH3', 'Učebna ITH3', 'vt3_2.jpg', 16, 1),
+                                                                                ('VRR', 'Učebna VRR+R', 'vrr.jpg', 5, 1),
+                                                                                ('VT2', 'VT2', 'vt3_2.jpg', 0, 1);
+
+INSERT INTO `computers` (`id`, `room_id`, `is_teachers_pc`, `available`) VALUES
+                                                                             ('ITH2_PC01', 'ITH2', 0, 1),
+                                                                             ('ITH2_PC02', 'ITH2', 0, 1),
+                                                                             ('ITH2_PC03', 'ITH2', 0, 1),
+                                                                             ('ITH2_PC04', 'ITH2', 0, 1),
+                                                                             ('ITH2_PC05', 'ITH2', 0, 1),
+                                                                             ('ITH2_PC06', 'ITH2', 0, 1),
+                                                                             ('ITH2_PC07', 'ITH2', 0, 1),
+                                                                             ('ITH2_PC08', 'ITH2', 0, 1),
+                                                                             ('ITH2_PC09', 'ITH2', 0, 1),
+                                                                             ('ITH2_PC10', 'ITH2', 0, 1),
+                                                                             ('ITH2_PC11', 'ITH2', 0, 1),
+                                                                             ('ITH2_PC12', 'ITH2', 0, 1),
+                                                                             ('ITH2_PC13', 'ITH2', 0, 1),
+                                                                             ('ITH2_PC14', 'ITH2', 0, 1),
+                                                                             ('ITH2_PC15', 'ITH2', 0, 1),
+                                                                             ('ITH2_PC16', 'ITH2', 0, 1),
+                                                                             ('ITH2_PC17', 'ITH2', 0, 1),
+                                                                             ('ITH2_PC18', 'ITH2', 0, 1),
+                                                                             ('ITH2_PC19', 'ITH2', 0, 1),
+                                                                             ('ITH2_PC20', 'ITH2', 0, 1),
+                                                                             ('ITH2_PC21', 'ITH2', 0, 1),
+                                                                             ('ITH2_PC22', 'ITH2', 0, 1),
+                                                                             ('ITH2_PC23', 'ITH2', 0, 1),
+                                                                             ('ITH2_PC24', 'ITH2', 0, 1),
+                                                                             ('ITH2_PC25', 'ITH2', 0, 1),
+                                                                             ('ITH2_PC26', 'ITH2', 0, 1),
+                                                                             ('ITH2_PC27', 'ITH2', 0, 1),
+                                                                             ('VRR_PC01', 'VRR', 0, 1),
+                                                                             ('VRR_PC02', 'VRR', 0, 1),
+                                                                             ('VRR_PC03', 'VRR', 0, 1),
+                                                                             ('VRR_PC04', 'VRR', 0, 1),
+                                                                             ('VRR_PC05', 'VRR', 0, 1),
+                                                                             ('VRR_PC06', 'VRR', 0, 1),
+                                                                             ('VRR_PC07', 'VRR', 0, 1),
+                                                                             ('VRR_PC08', 'VRR', 0, 1),
+                                                                             ('VRR_PC09', 'VRR', 1, 1),
+                                                                             ('VT2_PC01', 'VT2', 0, 0),
+                                                                             ('VT2_PC02', 'VT2', 0, 0),
+                                                                             ('VT2_PC03', 'VT2', 0, 0),
+                                                                             ('VT2_PC04', 'VT2', 0, 0),
+                                                                             ('VT2_PC05', 'VT2', 0, 0),
+                                                                             ('VT2_PC06', 'VT2', 0, 0),
+                                                                             ('VT2_PC07', 'VT2', 0, 0),
+                                                                             ('VT2_PC08', 'VT2', 0, 0),
+                                                                             ('VT2_PC09', 'VT2', 0, 0),
+                                                                             ('VT2_PC10', 'VT2', 0, 0),
+                                                                             ('VT2_PC11', 'VT2', 0, 0),
+                                                                             ('VT2_PC12', 'VT2', 0, 0),
+                                                                             ('VT2_PC13', 'VT2', 0, 0),
+                                                                             ('VT2_PC14', 'VT2', 0, 0),
+                                                                             ('VT2_PC15', 'VT2', 0, 0),
+                                                                             ('VT2_PC16', 'VT2', 0, 0),
+                                                                             ('VT2_PC17', 'VT2', 0, 0),
+                                                                             ('VT2_PC18', 'VT2', 0, 0),
+                                                                             ('VT2_PC19', 'VT2', 0, 0),
+                                                                             ('VT2_PC20', 'VT2', 0, 0),
+                                                                             ('VT2_PC21', 'VT2', 0, 0),
+                                                                             ('VT2_PC22', 'VT2', 0, 0),
+                                                                             ('VT2_PC23', 'VT2', 0, 0),
+                                                                             ('VT2_PC24', 'VT2', 0, 0),
+                                                                             ('VT2_PC25', 'VT2', 0, 0),
+                                                                             ('VT2_PC26', 'VT2', 0, 0),
+                                                                             ('VT2_PC27', 'VT2', 0, 0),
+                                                                             ('VT2_PC28', 'VT2', 0, 0),
+                                                                             ('VT2_PC29', 'VT2', 1, 0);
+
+INSERT INTO `users` (`id`, `display_name`, `email`, `password`, `class`, `gender`, `school`, `created_at` ,`last_updated`, `last_logged_in`, `account_type`, `avatar`, `banner`, `enable_reservation`) VALUES
+(1, 'Administrator', 'admin@admin.admin', '$2a$11$7XnPVemd77pb8WWQItw5d.azyOvrGgKN941CxPTVYy3515cCOhZ0K', 'SPECIAL', 'OTHER', 'EDUCHEM', '2025-04-09 00:14:10', '2025-04-09 00:14:10', '2025-04-09 00:14:10', 'SUPERADMIN', 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSzrViu6UGEqo8eEnSGQkf8497JBfHSLViSoQ&s', 'https://drscdn.500px.org/photo/1113771318/q%3D80_m%3D600/v2?sig=c18424903b06b1b1595af3bd506268530d582216cc8e319b110d3dfe7ec2d242', 0),
+(2, 'Miloš Navrátil', 'milos.navratil@example.com', '_', '1.A', 'MALE', 'EDUCHEM', '2025-04-09 00:14:10', '2025-06-14 14:56:11', NULL, 'STUDENT', NULL, NULL, 0),
+(3, 'Marek Svoboda', 'marek.svoboda@example.com', '_', NULL, 'MALE', 'SSSMEP', '2025-04-09 00:14:10', '2025-06-14 14:56:11', NULL, 'TEACHER', 'https://imgv3.fotor.com/images/blog-cover-image/a-shadow-of-a-boy-carrying-the-camera-with-red-sky-behind.jpg', NULL, 1),
+(4, 'Jana Pokorná', 'jana.pokorna@example.com', '_', NULL, 'FEMALE', 'EDUCHEM', '2025-04-09 00:14:10', '2025-06-14 14:56:11', NULL, 'ADMIN', 'https://iso.500px.com/wp-content/uploads/2016/02/stock-photo-114337435.jpg', NULL, 0),
+(5, 'Natálie Novotná', 'natalie.novotna@example.com', '_', '2.B', 'FEMALE', 'EDUCHEM', '2025-04-09 00:14:10', '2025-06-14 14:56:11', NULL, 'STUDENT', 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcThisxh_l6BA8BgSe7z2MUiaRj553YtM11PNA&s', NULL, 1),
+(6, 'Tomáš Dvořák', 'tomas.dvorak@example.com', '_', '3.A', 'MALE', 'SSSMEP', '2025-04-09 00:14:10', '2025-06-14 14:59:34', NULL, 'STUDENT', 'https://img.freepik.com/free-photo/couple-making-heart-from-hands-sea-shore_23-2148019887.jpg?semt=ais_hybrid&w=740', NULL, 0),
+(7, 'Lucie Králová', 'lucie.kralova@example.com', '_', '1.B', 'FEMALE', 'SSSMEP', '2025-04-09 00:14:10', '2025-06-14 14:59:34', NULL, 'STUDENT', NULL, NULL, 1),
+(8, 'Petr Černý', 'petr.cerny@example.com', '_', '2.A', 'MALE', 'EDUCHEM', '2025-04-09 00:14:10', '2025-06-14 14:59:34', NULL, 'STUDENT', 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRvFBa3G11OUBYADP7ouSBgwiiRzSYorF4dfg&s', NULL, 1),
+(9, 'Eliška Horáková', 'eliska.horakova@example.com', '_', '3.B', 'FEMALE', 'EDUCHEM', '2025-04-09 00:14:10', '2025-06-14 14:59:34', NULL, 'STUDENT', NULL, NULL, 1),
+(10, 'Adam Nový', 'adam.novy@example.com', '_', NULL, 'MALE', 'SSSMEP', '2025-04-09 00:14:10', '2025-06-14 14:59:34', NULL, 'TEACHER', 'https://www.shutterstock.com/image-photo/passport-photo-portrait-young-man-260nw-2437772333.jpg', 'https://static.vecteezy.com/system/resources/thumbnails/022/902/924/small/ai-generative-modern-luxury-real-estate-house-for-sale-and-rent-luxury-property-residence-concept-photo.jpg', 0),
+(11, 'Simona Benešová', 'simona.benesova@example.com', '_', NULL, 'FEMALE', 'EDUCHEM', '2025-04-09 00:14:10', '2025-06-14 14:59:34', NULL, 'TEACHER', 'https://img.freepik.com/premium-photo/giving-rose-png-badge-sticker-valentines-day-photo-heart-shape-transparent-background_53876-950839.jpg?semt=ais_hybrid&w=740', 'https://static.vecteezy.com/system/resources/thumbnails/054/587/101/small_2x/romantic-rose-backdrop-with-intertwined-blooms-and-hearts-for-valentines-day-highlighting-love-and-passion-with-a-warm-color-palette-perfect-for-romantic-settings-and-event-design-concepts-photo.jpeg', 0),
+(12, 'Ondřej Kolář', 'ondrej.kolar@example.com', '_', '1.C', 'MALE', 'EDUCHEM', '2025-04-09 00:14:10', '2025-06-14 14:59:34', NULL, 'STUDENT', 'https://5.imimg.com/data5/SELLER/Default/2023/4/300935887/RK/PR/IE/4354612/img-20220703-wa0001-500x500.jpg', NULL, 0),
+(13, 'Tereza Malá', 'tereza.mala@example.com', '_', '2.C', 'FEMALE', 'SSSMEP', '2025-04-09 00:14:10', '2025-06-14 14:59:34', NULL, 'STUDENT', NULL, NULL, 1),
+(14, 'Roman Havel', 'roman.havel@example.com', '_', NULL, 'MALE', 'EDUCHEM', '2025-04-09 00:14:10', '2025-06-14 14:59:34', NULL, 'ADMIN', NULL, NULL, 0),
+(15, 'Barbora Němcová', 'barbora.nemcova@example.com', '_', '3.C', 'FEMALE', 'EDUCHEM', '2025-04-09 00:14:10', '2025-06-14 14:59:34', NULL, 'STUDENT', 'https://st2.depositphotos.com/2001755/5408/i/450/depositphotos_54081723-stock-photo-beautiful-nature-landscape.jpg', NULL, 0),
+(16, 'Filip Růžička', 'filip.ruzicka@example.com', '_', '1.A', 'MALE', 'EDUCHEM', '2025-04-09 00:14:10', '2025-06-14 14:59:34', NULL, 'STUDENT', NULL, NULL, 0),
+(17, 'Nikola Procházková', 'nikola.prochazkova@example.com', '_', '2.B', 'FEMALE', 'EDUCHEM', '2025-04-09 00:14:10', '2025-06-14 14:59:34', NULL, 'STUDENT', NULL, NULL, 0),
+(18, 'Daniel Konečný', 'daniel.konecny@example.com', '_', '4.A', 'MALE', 'SSSMEP', '2025-04-09 00:14:10', '2025-06-14 14:59:34', NULL, 'STUDENT', 'https://i.pinimg.com/236x/d3/4b/ec/d34becc9ecf6f8b4b5c861bf61109176.jpg', NULL, 0),
+(19, 'Veronika Blažková', 'veronika.blazkova@example.com', '_', '1.B', 'FEMALE', 'EDUCHEM', '2025-04-09 00:14:10', '2025-06-14 14:59:34', NULL, 'STUDENT', NULL, NULL, 0),
+(20, 'Jakub Fiala', 'jakub.fiala@example.com', '_', '3.A', 'MALE', 'EDUCHEM', '2025-04-09 00:14:10', '2025-06-14 14:59:34', NULL, 'STUDENT', NULL, NULL, 0),
+(21, 'Kristýna Doležalová', 'kristyna.dolezalova@example.com', '_', NULL, 'FEMALE', 'EDUCHEM', '2025-04-09 00:14:10', '2025-06-14 14:59:34', NULL, 'ADMIN', NULL, NULL, 0),
+(22, 'David Marek', 'david.marek@example.com', '_', '2.C', 'MALE', 'EDUCHEM', '2025-04-09 00:14:10', '2025-06-14 14:59:34', NULL, 'STUDENT', NULL, NULL, 0),
+(23, 'Kateřina Holubová', 'katerina.holubova@example.com', '_', '3.B', 'FEMALE', 'EDUCHEM', '2025-04-09 00:14:10', '2025-06-14 14:59:34', NULL, 'STUDENT', NULL, NULL, 1),
+(24, 'Matěj Šimek', 'matej.simek@example.com', '_', NULL, 'MALE', 'SSSMEP', '2025-04-09 00:14:10', '2025-06-14 14:59:34', NULL, 'TEACHER', 'https://i.pinimg.com/236x/39/8f/da/398fdab4318b3baa65d36baf5ab3fab4.jpg', 'https://static8.depositphotos.com/1491329/1068/i/450/depositphotos_10687188-stock-photo-foggy-landscape-early-morning-mist.jpg', 1),
+(25, 'Alena Sedláčková', 'alena.sedlackova@example.com', '_', '1.C', 'FEMALE', 'EDUCHEM', '2025-04-09 00:14:10', '2025-06-14 14:59:34', NULL, 'STUDENT', NULL, NULL, 0);
 
 INSERT INTO `reservations` (`user_id`, `room_id`, `computer_id`, `note`, `created_at`) VALUES
 (3, NULL, 'ITH2_PC15', NULL, '2025-06-14 14:57:51'),

--- a/educhemlp.client/src/interfaces.ts
+++ b/educhemlp.client/src/interfaces.ts
@@ -8,6 +8,7 @@ export type LoggedUser = {
     email: string,
     type: AccountType,
     gender: "MALE" | "FEMALE" | "OTHER" | null,
+    school: AccountSchool,
     avatar: string | null,
     connections: string[] | null,
     banner: string | null,
@@ -44,6 +45,11 @@ export enum AccountType {
 
 export enum AccountGender {
     MALE, FEMALE, OTHER
+}
+
+export enum AccountSchool {
+    EDUCHEM = "EDUCHEM",
+    SSSMEP = "SSSMEP",
 }
 
 /*

--- a/educhemlp.client/src/pages/app/Administration.tsx
+++ b/educhemlp.client/src/pages/app/Administration.tsx
@@ -8,7 +8,7 @@ import {Modal} from "../../components/modals/Modal.tsx";
 import {TextWithIcon} from "../../components/TextWithIcon.tsx";
 import {toast} from "react-toastify";
 import Switch from "../../components/Switch.tsx";
-import {AccountGender, AccountType, AppSettings, BasicAPIResponse, Log, LoggedUser} from "../../interfaces.ts";
+import {AccountGender, AccountSchool, AccountType, AppSettings, BasicAPIResponse, Log, LoggedUser} from "../../interfaces.ts";
 import {
     authUser,
     compareEnumValues,
@@ -36,6 +36,7 @@ interface User {
     class: string,
     type: AccountType,
     gender: AccountGender | null,
+    school: AccountSchool,
     createdAt: string,
     lastUpdated: string,
     lastLoggedIn: string,
@@ -149,6 +150,17 @@ function translateAccountType(type: AccountType | null | undefined, gender: Acco
     }
 }
 
+function translateSchool(school: AccountSchool | string | null | undefined) {
+    switch (school?.toString()) {
+        case "SSSMEP":
+            return "SSŠMEP";
+        case "EDUCHEM":
+            return "Educhem";
+        default:
+            return "Neznámá";
+    }
+}
+
 // endregion
 
 
@@ -165,6 +177,7 @@ const UsersTab = () => {
     const [selectedAccountTypes, setSelectedAccountTypes] = useState<Set<string>>(new Set());
     const [selectedGenders, setSelectedGenders] = useState<Set<string>>(new Set());
     const [selectedClasses, setSelectedClasses] = useState<Set<string>>(new Set());
+    const [selectedSchools, setSelectedSchools] = useState<Set<string>>(new Set());
     const [enabledReservationFilter, setEnabledReservationFilter] = useState<string>("all");
 
     const closeModal = useAdminStore((state) => state.closeModal);
@@ -201,6 +214,7 @@ const UsersTab = () => {
     const uniqueAccountTypes = Array.from(new Set(users?.map((user) => user.type?.toString()).filter((t): t is string => !!t) || [])).sort();
     const uniqueGenders = Array.from(new Set(users?.map((user) => user.gender?.toString()).filter((g): g is string => !!g) || [])).sort();
     const uniqueClasses = Array.from(new Set(users?.map((user) => user.class).filter((c): c is string => !!c) || [])).sort();
+    const uniqueSchools = Array.from(new Set(users?.map((user) => user.school?.toString()).filter((s): s is string => !!s) || [])).sort();
 
     // Toggle filters
     const toggleAccountType = (type: string) => {
@@ -239,6 +253,18 @@ const UsersTab = () => {
         });
     };
 
+    const toggleSchool = (school: string) => {
+        setSelectedSchools((prev) => {
+            const newSet = new Set(prev);
+            if (newSet.has(school)) {
+                newSet.delete(school);
+            } else {
+                newSet.add(school);
+            }
+            return newSet;
+        });
+    };
+
     const filteredAndSortedUsers = users
         ?.filter((user) =>
             user.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
@@ -257,6 +283,11 @@ const UsersTab = () => {
             
             // Filter by class
             if (selectedClasses.size > 0 && !selectedClasses.has(user.class ?? "")) {
+                return false;
+            }
+
+            // Filter by school
+            if (selectedSchools.size > 0 && !selectedSchools.has(user.school?.toString() ?? "")) {
                 return false;
             }
 
@@ -310,6 +341,7 @@ const UsersTab = () => {
         const email = (userModal.querySelector("input[name='email']") as HTMLInputElement).value;
         let cls: string | null = (userModal.querySelector("input[name='class']") as HTMLInputElement).value;
         const gender = (userModal.querySelector("select[name='gender']") as HTMLSelectElement).value;
+        const school = (userModal.querySelector("select[name='school']") as HTMLSelectElement).value;
         const accountType = (userModal.querySelector("select[name='accountType']") as HTMLSelectElement).value;
         const enableReservation = (userModal.querySelector("input[name='enableReservation']") as HTMLInputElement)?.checked ?? false;
 
@@ -338,6 +370,7 @@ const UsersTab = () => {
                 class: cls,
                 type: accountType,
                 gender: gender,
+                school: school,
                 enableReservation: enableReservation,
             })
         }).then(async res => {
@@ -365,6 +398,7 @@ const UsersTab = () => {
         const email = (userModal.querySelector("input[name='email']") as HTMLInputElement).value;
         let cls: string | null = (userModal.querySelector("input[name='class']") as HTMLInputElement).value;
         const gender = (userModal.querySelector("select[name='gender']") as HTMLSelectElement).value;
+        const school = (userModal.querySelector("select[name='school']") as HTMLSelectElement).value;
         const accountType = (userModal.querySelector("select[name='accountType']") as HTMLSelectElement).value;
         const sendToEmail = (userModal.querySelector("input[name='sendToEmail']") as HTMLInputElement).checked;
         const enableReservation = (userModal.querySelector("input[name='enableReservation']") as HTMLInputElement)?.checked ?? false;
@@ -394,6 +428,7 @@ const UsersTab = () => {
                 class: cls,
                 type: accountType,
                 gender: gender,
+                school: school,
                 sendToEmail: sendToEmail,
                 enableReservation: enableReservation,
             })
@@ -669,6 +704,20 @@ const UsersTab = () => {
                                         )
                                     }
                                 </div>
+
+                                <div className="child" title="Škola">
+                                    <div className="icon" style={{maskImage: `url(/images/icons/organization.svg)`}}></div>
+                                    {
+                                        !userModalEditMode ? (
+                                            <p>{translateSchool(selectedUser?.school)}</p>
+                                        ) : (
+                                            <select name="school" defaultValue={selectedUser?.school ?? "EDUCHEM"}>
+                                                <option value="EDUCHEM">Educhem</option>
+                                                <option value="SSSMEP">SSŠMEP</option>
+                                            </select>
+                                        )
+                                    }
+                                </div>
                             </div>
 
                             {
@@ -847,6 +896,22 @@ const UsersTab = () => {
                             </div>
 
                             <div className="filter-section">
+                                <p className="filter-label">Škola:</p>
+                                <div className="filter-checkboxes">
+                                    {uniqueSchools.map((school) => (
+                                        <label key={school} className="checkbox-label">
+                                            <input
+                                                type="checkbox"
+                                                checked={selectedSchools.has(school)}
+                                                onChange={() => toggleSchool(school)}
+                                            />
+                                            <span>{translateSchool(school)}</span>
+                                        </label>
+                                    ))}
+                                </div>
+                            </div>
+
+                            <div className="filter-section">
                                 <p className="filter-label">Rezervace:</p>
                                 <div className="filter-checkboxes">
                                     <label className="checkbox-label">
@@ -888,6 +953,7 @@ const UsersTab = () => {
                             <th onClick={() => handleSort("name")}>Jméno a příjmení</th>
                             <th onClick={() => handleSort("email")}>Email</th>
                             <th onClick={() => handleSort("gender")}>Pohlaví</th>
+                            <th onClick={() => handleSort("school")}>Škola</th>
                             <th onClick={() => handleSort("class")}>Třída</th>
                             <th onClick={() => handleSort("type")}>Typ účtu</th>
                             <th onClick={() => handleSort("createdAt")}>Vytvořen</th>
@@ -919,6 +985,7 @@ const UsersTab = () => {
                                 </td>
                                 <td>{user.email}</td>
                                 <td>{translateGender(user.gender?.toString())}</td>
+                                <td>{translateSchool(user.school)}</td>
                                 <td>{user.class}</td>
                                 <td>{translateAccountType(user.type, user.gender)}</td>
                                 <td>{new Date(user.createdAt).toLocaleString()}</td>

--- a/educhemlp.client/src/pages/app/Reservations.tsx
+++ b/educhemlp.client/src/pages/app/Reservations.tsx
@@ -70,6 +70,7 @@ interface Reservation {
         id: number,
         displayName: string,
         class: string,
+        school?: "EDUCHEM" | "SSSMEP" | null,
         avatar: string | null,
         banner: string | null,
     } | "unknown", // kdyz uzivatel neni prihlasen, dropne to "unknown"
@@ -259,7 +260,10 @@ const SelectedReservation = memo(() => {
                                 <p title={reservation?.user?.displayName}>
                                     {reservation?.user?.displayName}{" "}
                                 </p>
-                                <span>{reservation?.user?.class}</span>
+                                <span>
+                                    {reservation?.user?.class}
+                                    {reservation?.user?.school ? ` • ${reservation.user.school === "SSSMEP" ? "SSŠMEP" : "Educhem"}` : ""}
+                                </span>
                             </div>
                             {/* poznamka: pokud budes chtit cas, odkomentuj a dopln createdAt
                         <p className="date">
@@ -283,7 +287,10 @@ const SelectedReservation = memo(() => {
                 />
                 <p title={user?.displayName}>{user?.displayName}</p>
             </div>
-            <p className="class">{user?.class}</p>
+            <p className="class">
+                {user?.class}
+                {user?.school ? ` • ${user.school === "SSSMEP" ? "SSŠMEP" : "Educhem"}` : ""}
+            </p>
         </div>
     );
 
@@ -997,7 +1004,13 @@ export const Reservations = () => {
                                                         <div className={"banner profilebannercustomization"} style={{ '--banner': `url(${reservation.user?.banner})`  } as CSSProperties}></div>
 
                                                         <div className="texts">
-                                                            <p className={"name"}>{reservation.user?.displayName} <span>{reservation.user?.class}</span></p>
+                                                            <p className={"name"}>
+                                                                {reservation.user?.displayName}{" "}
+                                                                <span>
+                                                                    {reservation.user?.class}
+                                                                    {reservation.user?.school ? ` • ${reservation.user.school === "SSSMEP" ? "SSŠMEP" : "Educhem"}` : ""}
+                                                                </span>
+                                                            </p>
                                                             <p className={"id"}>{reservation.computer?.id ?? reservation.room?.label}</p>
                                                             <p className={"date"}>{new Date(reservation.createdAt).toLocaleString("cs-CZ" )}</p>
                                                         </div>


### PR DESCRIPTION
Introduce AccountSchool (EDUCHEM/SSSMEP) and wire it through the stack: add School property and enum to Account, accept/parse school in API create/update endpoints, update AccountRepository and IAccountRepository CreateAsync signatures to include school, and include school in WebSocket reservation payloads. Update client types and administration UI to show, translate and filter by school. DB schema updated to add users.school (default EDUCHEM), adjust collations, seed data, and extend users_access_tokens/platforms and account_type definitions. Note: repository interface/signature changes are breaking and require recompilation/migration of DB data to include the new column.