### PR TITLE
FEAT: Add reservation cache reset endpoint and UI

### DIFF
--- a/EduchemLP.Server/API/APIv1.cs
+++ b/EduchemLP.Server/API/APIv1.cs
@@ -5,6 +5,7 @@ using EduchemLP.Server.Classes.Objects;
 using EduchemLP.Server.Models;
 using EduchemLP.Server.Repositories;
 using EduchemLP.Server.Services;
+using EduchemLP.Server.WebSockets;
 using Microsoft.AspNetCore.Mvc;
 using MySqlConnector;
 
@@ -19,7 +20,8 @@ public class APIv1(
     IDbLoggerService dbLogger,
     IAppSettingsService appSettings,
     IAccountRepository accounts,
-    IWebSocketHub webSocketHub
+    IWebSocketHub webSocketHub,
+    ReservationsWebSocketEndpoint reservationsWebSocketEndpoint
 ) : Controller {
 
 
@@ -263,6 +265,17 @@ public class APIv1(
 
         Task.WaitAll(t1, t2, t3, t4);
         return new NoContentResult();
+    }
+
+    [HttpPost("adm/reservations/snapshot/reset")]
+    public async Task<IActionResult> ResetReservationsSnapshot(CancellationToken ct = default) {
+        var acc = await auth.ReAuthFromContextOrNullAsync(ct);
+        if(acc == null || acc.Type < Account.AccountType.ADMIN) return new UnauthorizedObjectResult(new { success = false, message = "Nelze resetovat cache rezervací, pokud nejsi přihlášený, nebo nemáš dostatečná práva." });
+
+        await reservationsWebSocketEndpoint.ResetSnapshotAsync(ct);
+        await dbLogger.LogInfoAsync($"Uživatel {acc.DisplayName} ({acc.Email}) resetoval cache rezervací.", "reservation-cache-reset", ct);
+
+        return new JsonResult(new { success = true, message = "Cache rezervací byla resetována." });
     }
 
 

--- a/EduchemLP.Server/Program.cs
+++ b/EduchemLP.Server/Program.cs
@@ -112,7 +112,8 @@ public static class Program {
         builder.Services.AddSingleton<IWebSocketHub, WebSocketHub>();
         builder.Services.AddHostedService<WebSocketHeartbeatService>();
         builder.Services.AddSingleton<IWebSocketEndpoint, ChatWebSocketEndpoint>();
-        builder.Services.AddSingleton<IWebSocketEndpoint, ReservationsWebSocketEndpoint>();
+        builder.Services.AddSingleton<ReservationsWebSocketEndpoint>();
+        builder.Services.AddSingleton<IWebSocketEndpoint>(sp => sp.GetRequiredService<ReservationsWebSocketEndpoint>());
         builder.Services.AddSingleton<IWebSocketEndpoint, SyncWebSocketEndpoint>();
 
         #if DEBUG

--- a/EduchemLP.Server/WebSockets/ReservationsWebSocketEndpoint.cs
+++ b/EduchemLP.Server/WebSockets/ReservationsWebSocketEndpoint.cs
@@ -356,6 +356,10 @@ public sealed class ReservationsWebSocketEndpoint(
     }
 
     // vynuti nove nacteni snapshotu z db a pak broadcast vsem
+    public Task ResetSnapshotAsync(CancellationToken ct = default) {
+        return ReloadAndBroadcastFullReservationInfoAsync(ct);
+    }
+
     private async Task ReloadAndBroadcastFullReservationInfoAsync(CancellationToken ct) {
         ReservationSnapshot snapshot;
 

--- a/educhemlp.client/src/pages/app/Administration.scss
+++ b/educhemlp.client/src/pages/app/Administration.scss
@@ -305,6 +305,22 @@
                 width: calc(100%/2 - 8px);
             }
         }
+
+        .cache-reset {
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+            margin-top: 8px;
+
+            >p {
+                color: var(--text-color-secondary);
+                font-weight: 600;
+            }
+
+            >button {
+                width: 100%;
+            }
+        }
     }
 }
 

--- a/educhemlp.client/src/pages/app/Administration.tsx
+++ b/educhemlp.client/src/pages/app/Administration.tsx
@@ -1219,6 +1219,7 @@ const AppSettingsTab = () => {
     const appSettings: AppSettings | null = useStore((state) => state.appSettings);
     const setAppSettings = useStore((state) => state.setAppSettings);
     const [reservationsStatus, setReservationsStatus] = useState(appSettings?.reservationsStatus ?? "CLOSED");
+    const [reservationCacheResetting, setReservationCacheResetting] = useState(false);
 
 
 
@@ -1298,6 +1299,30 @@ const AppSettingsTab = () => {
         setReservationsStatus(appSettings?.reservationsStatus ?? "CLOSED");
     }
 
+    function resetReservationsCache() {
+        if (reservationCacheResetting) return;
+
+        setReservationCacheResetting(true);
+        fetch("/api/v1/adm/reservations/snapshot/reset", {
+            method: "POST",
+        }).then(async res => {
+            const data: BasicAPIResponse | null = res.headers.get("content-type")?.includes("application/json")
+                ? await res.json()
+                : null;
+
+            if (!res.ok || data?.success === false) {
+                toast.error(data?.message ?? "Chyba při resetu cache rezervací.");
+                return;
+            }
+
+            toast.success(data?.message ?? "Cache rezervací úspěšně resetována.");
+        }).catch(() => {
+            toast.error("Chyba při resetu cache rezervací.");
+        }).finally(() => {
+            setReservationCacheResetting(false);
+        });
+    }
+
     function toDatetimeLocal(utcString: string) {
         const date = new Date(utcString);
         const pad = (n: number) => n.toString().padStart(2, '0');
@@ -1357,6 +1382,17 @@ const AppSettingsTab = () => {
                 <div className="buttons">
                     <Button type={ButtonType.SECONDARY} text="Zrušit změny" onClick={() => resetEditAppSettingsForm() } />
                     <Button type={ButtonType.PRIMARY} text="Uložit změny" form="editappsettings" buttonType="submit" />
+                </div>
+
+                <div className="cache-reset">
+                    <p>Cache rezervací</p>
+                    <Button
+                        type={ButtonType.SECONDARY}
+                        text="Resetovat cache"
+                        onClick={resetReservationsCache}
+                        loading={reservationCacheResetting}
+                        disabled={reservationCacheResetting}
+                    />
                 </div>
             </div>
 


### PR DESCRIPTION
Expose POST /api/v1/adm/reservations/snapshot/reset to let admins force a reload/broadcast of the reservations snapshot. APIv1 now injects ReservationsWebSocketEndpoint and logs the action. Program.cs registers ReservationsWebSocketEndpoint as a concrete singleton and maps it to IWebSocketEndpoint so it can be injected. ReservationsWebSocketEndpoint gained ResetSnapshotAsync which triggers ReloadAndBroadcastFullReservationInfoAsync. Client-side Administration page and styles were updated: added a cache-reset button, loading state, fetch call with toast feedback, and related SCSS.